### PR TITLE
Add Playwright UI regression test template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# playwright-python-example
+# Playwright Python Example
+
+This template demonstrates how to write an end-to-end test using [Playwright](https://playwright.dev/python) and `pytest` for UI regression testing.
+
+The included test opens the QBench login page at `https://srqaengineer-sf-uat.qbench.net/` and checks the page against a stored screenshot.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+playwright install
+```
+
+## Running the tests
+
+On the first run, generate baseline screenshots:
+
+```bash
+pytest --update-snapshots
+```
+
+Subsequent runs will compare the current UI to the baseline:
+
+```bash
+pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+playwright
+pytest
+pytest-playwright

--- a/tests/test_ui_regression.py
+++ b/tests/test_ui_regression.py
@@ -1,0 +1,8 @@
+from playwright.sync_api import Page, expect
+
+BASE_URL = "https://srqaengineer-sf-uat.qbench.net/"
+
+def test_login_page_visual_regression(page: Page) -> None:
+    page.goto(BASE_URL)
+    expect(page).to_have_url(BASE_URL)
+    expect(page).to_have_screenshot()


### PR DESCRIPTION
## Summary
- add example Playwright test that loads QBench login page and checks screenshot for UI regression
- document setup and test execution steps
- declare Python dependencies for Playwright and pytest

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement playwright)*
- `pytest tests/test_ui_regression.py -vv` *(fails: No module named 'playwright')*


------
https://chatgpt.com/codex/tasks/task_e_68a4be96b5a083328b21372b74439cfe