### PR TITLE
Add virtual environment setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@ The included test opens the QBench login page at `https://srqaengineer-sf-uat.qb
 
 ## Setup
 
+Create and activate a virtual environment:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # On Windows use .venv\Scripts\activate
+```
+
+Install the dependencies and Playwright browsers:
+
 ```bash
 pip install -r requirements.txt
 playwright install

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 playwright
 pytest
 pytest-playwright
+virtualenv


### PR DESCRIPTION
## Summary
- add `virtualenv` dependency
- guide users to create and activate a virtual environment before installing dependencies

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement virtualenv - 403 Forbidden)*
- `pytest` *(fails: BrowserType.launch: Executable doesn't exist ... playwright install)*
- `playwright install` *(fails: Download failed: server returned code 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c1c96ec883328b4cf48c3b701cea