### PR TITLE
Use secret env vars in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      BASE_URL: ${{ secrets.BASE_URL }}
+      USER_EMAIL: ${{ secrets.USER_EMAIL }}
+      USER_PASSWORD: ${{ secrets.USER_PASSWORD }}
     strategy:
       matrix:
         browser: [chromium, webkit]

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ playwright install
 ```
 
 Environment variables `BASE_URL`, `USER_EMAIL`, and `USER_PASSWORD` may be
-stored in a `.env` file or exported in the shell.
+stored in a `.env` file or exported in the shell. The continuous integration
+workflow expects these values to be provided through repository secrets.
 
 ## Running the tests
 


### PR DESCRIPTION
## Summary
- load BASE_URL, USER_EMAIL, and USER_PASSWORD from repository secrets for CI
- document how CI uses repository secrets for required env vars

## Testing
- `BASE_URL=http://example.com USER_EMAIL=test@example.com USER_PASSWORD=pass pytest` *(fails: Bro...)*

------
https://chatgpt.com/codex/tasks/task_e_68a618d655908332add4fadaa9d89954